### PR TITLE
[MERL-125] Add Single Post

### DIFF
--- a/src/components/ContentWrapper/ContentWrapper.js
+++ b/src/components/ContentWrapper/ContentWrapper.js
@@ -1,6 +1,8 @@
+import styles from './ContentWrapper.module.scss';
+
 export default function ContentWrapper({ content, className, children }) {
   return (
-    <article className={['content', className].join(' ')}>
+    <article className={[styles['content'], className].join(' ')}>
       <div dangerouslySetInnerHTML={{ __html: content ?? '' }} />
       {children}
     </article>

--- a/src/components/ContentWrapper/ContentWrapper.module.scss
+++ b/src/components/ContentWrapper/ContentWrapper.module.scss
@@ -5,6 +5,16 @@
   margin: 0 auto;
 
   :global {
+
+    * {
+      max-width: 100%;
+    }
+
+    figure {
+      margin-left: 0;
+      margin-right: 0;
+    }
+
     h1, h2, h3, h4, h5, h6 {
       margin: 4.8rem 0;
     }

--- a/src/components/ContentWrapper/ContentWrapper.module.scss
+++ b/src/components/ContentWrapper/ContentWrapper.module.scss
@@ -1,0 +1,112 @@
+@import "../../styles/Variables";
+
+.content {
+  max-width: $grid-max-width;
+  margin: 0 auto;
+
+  :global {
+    h1, h2, h3, h4, h5, h6 {
+      margin: 4.8rem 0;
+    }
+
+    strong {
+      font-weight: 700;
+    }
+
+    a {
+      color: var(--color-black);
+      text-decoration: underline;
+    }
+
+    li {
+      font-size: 1.6rem;
+    }
+
+    img {
+      display: block;
+      height: auto;
+      max-width: 100%;
+    }
+
+    .alignleft {
+      display: inline;
+      float: left;
+      margin-right: 1.5em;
+    }
+
+    .alignright {
+      display: inline;
+      float: right;
+      margin-left: 1.5em;
+    }
+
+    .aligncenter {
+      clear: both;
+      display: block;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    code,
+    pre {
+      color: var(--color-white);
+      background: var(--color-black);
+    }
+
+    code {
+      padding: 0.25rem .5rem;
+    }
+
+    pre {
+      max-width: 100%;
+      overflow: auto;
+      padding: 1rem;
+    }
+
+    blockquote {
+      border-top: 1px solid var(--color-black);
+      border-bottom: 1px solid var(--color-black);
+      font-style: italic;
+      margin-top: 0;
+      margin-left: 0;
+      margin-right: 0;
+      padding: 4rem 1rem 4rem;
+      text-align: center;
+
+      &::before {
+        content: '”';
+        display: block;
+        font-size: 6rem;
+        line-height: 0;
+        margin: 2rem 0;
+      }
+
+      > *:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    table {
+      border-collapse: collapse;
+      width: 100%;
+    }
+
+    thead th {
+      border-bottom: 1px solid var(--color-secondary);
+      padding-bottom: 0.5em;
+    }
+
+    th {
+      padding: 0.4rem 0;
+      text-align: left;
+    }
+
+    tr {
+      border-bottom: 1px solid var(--color-secondary);
+    }
+
+    td {
+      padding: 0.4em;
+    }
+  }
+}

--- a/src/components/TaxonomyTerms/TaxonomyTerms.js
+++ b/src/components/TaxonomyTerms/TaxonomyTerms.js
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+import styles from './TaxonomyTerms.module.scss';
+
+export default function TaxonomyTerms({ post, taxonomy }) {
+  const termLinks = post?.[taxonomy]()?.edges.map((edge) => {
+    const { name, uri } = edge?.node;
+    return uri && <Link href={uri}>{name}</Link>;
+  });
+
+  return (
+    <div>
+      <span className={styles['taxonomy']}>{taxonomy}:</span>
+      <span className={styles['term-links']}>{termLinks}</span>
+    </div>
+  );
+}

--- a/src/components/TaxonomyTerms/TaxonomyTerms.module.scss
+++ b/src/components/TaxonomyTerms/TaxonomyTerms.module.scss
@@ -1,0 +1,25 @@
+@import "../../styles/Variables";
+
+.taxonomy {
+  font-weight: 700;
+  text-transform: uppercase;
+  margin-right: 0.8rem;
+}
+
+.term-links {
+  :global {
+    a {
+      position: relative;
+    }
+
+    a + a {
+      margin-left: 1rem;
+
+      &::before {
+        content: ', ';
+        position: absolute;
+        left: -1rem;
+      }
+    }
+  }
+}

--- a/src/components/TaxonomyTerms/index.js
+++ b/src/components/TaxonomyTerms/index.js
@@ -1,0 +1,3 @@
+import TaxonomyTerms from './TaxonomyTerms';
+
+export default TaxonomyTerms;

--- a/src/components/ThemeStyles/ThemeStyles.js
+++ b/src/components/ThemeStyles/ThemeStyles.js
@@ -4,7 +4,7 @@ const themes = {
   blue: {
     '--color-black': '#000',
     '--color-primary': '#000066',
-    '---color-secondary': '#cccccc',
+    '--color-secondary': '#cccccc',
     '--color-tertiary': '#eeeeee',
     '--color-white': '#ffffff',
   },
@@ -32,7 +32,7 @@ export default function ThemeStyles() {
       :root {
         --color-black: ${themes[themeColor]['--color-black']};
         --color-primary: ${themes[themeColor]['--color-primary']};
-        ---color-secondary: ${themes[themeColor]['---color-secondary']};
+        --color-secondary: ${themes[themeColor]['--color-secondary']};
         --color-tertiary: ${themes[themeColor]['--color-tertiary']};
         --color-white: ${themes[themeColor]['--color-white']};
       }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,6 +6,7 @@ import LoadMore from './LoadMore';
 import NavigationMenu from './NavigationMenu';
 import FeaturedImage from './FeaturedImage';
 import ContentWrapper from './ContentWrapper';
+import TaxonomyTerms from './TaxonomyTerms';
 import Projects from './Projects';
 import Footer from './Footer/Footer';
 import Main from './Main/Main';
@@ -22,6 +23,7 @@ export {
   FeaturedImage,
   ContentWrapper,
   LoadMore,
+  TaxonomyTerms,
   Projects,
   Footer,
   Main,

--- a/src/pages/posts/[postSlug]/index.js
+++ b/src/pages/posts/[postSlug]/index.js
@@ -1,11 +1,12 @@
 import { getNextStaticProps, is404 } from '@faustjs/next';
 import { client } from 'client';
-import { ContentWrapper, Footer, Header, Main } from 'components';
+import { ContentWrapper, Footer, Header, Main, TaxonomyTerms } from 'components';
 import Head from 'next/head';
 
 export function PostComponent({ post }) {
   const { useQuery } = client;
   const generalSettings = useQuery().generalSettings;
+
   return (
     <>
       <Head>
@@ -22,7 +23,10 @@ export function PostComponent({ post }) {
       />
 
       <Main className="container">
-        <ContentWrapper content={post?.content()} />
+        <ContentWrapper content={post?.content()}>
+          <TaxonomyTerms post={post} taxonomy={'categories'} />
+          <TaxonomyTerms post={post} taxonomy={'tags'} />
+        </ContentWrapper>
       </Main>
 
       <Footer />

--- a/src/styles/_Base.scss
+++ b/src/styles/_Base.scss
@@ -56,6 +56,10 @@ ul {
   list-style: circle inside;
 }
 
+dt {
+  font-weight: 700;
+}
+
 // Dividers
 hr {
   border: 0;

--- a/src/styles/_Grid.scss
+++ b/src/styles/_Grid.scss
@@ -11,11 +11,6 @@
   width: 100%;
 }
 
-.content {
-  max-width: $grid-max-width;
-  margin: 0 auto;
-}
-
 .row {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This polishes up our posts (and page) styles for WordPress content and adds a way for users to add linkable taxonomy terms

## Testing:

1. Import the https://raw.githubusercontent.com/WPTT/theme-unit-test/master/themeunittestdata.wordpress.xml using WordPress' XML importer.
2. Check Images on http://localhost:3000/posts/markup-image-alignment
3. Check HTML markup on http://localhost:3000/posts/markup-html-tags-and-formatting

## Sceenshots

<img width="948" alt="Screen Shot 2022-03-17 at 12 57 47 PM" src="https://user-images.githubusercontent.com/6676674/158853976-a7d25808-8d20-4dbc-9b23-c7237331ab66.png">

<img width="848" alt="Screen Shot 2022-03-17 at 12 57 53 PM" src="https://user-images.githubusercontent.com/6676674/158853984-9bf2d73c-dc6a-435e-89c1-dc5f75748822.png">

<img width="911" alt="Screen Shot 2022-03-17 at 12 50 09 PM" src="https://user-images.githubusercontent.com/6676674/158853993-48a12da1-dcb1-48e8-b180-41c50abb0e2f.png">

<img width="818" alt="Screen Shot 2022-03-17 at 12 59 58 PM" src="https://user-images.githubusercontent.com/6676674/158854088-b0f600f1-7c32-4fa4-a835-78fc4ca3fb20.png">

