### PR TITLE
[MERL-157] Replace hardcoded path prefixes

### DIFF
--- a/src/pages/category/[categorySlug]/index.js
+++ b/src/pages/category/[categorySlug]/index.js
@@ -39,7 +39,6 @@ export default function Page() {
       <Header title={`Category: ${category?.name}`} />
 
       <Main className="container">
-        <Heading level="h2">Category: {category?.name}</Heading>
         <Posts posts={data.nodes} />
         <LoadMore
           className="text-center"

--- a/src/pages/category/index.js
+++ b/src/pages/category/index.js
@@ -25,11 +25,11 @@ export default function Page() {
         <div className="content">
           <h1>All Categories</h1>
           <ul>
-            {categories?.nodes?.map(({ id, name }) => {
+            {categories?.nodes?.map(({ id, name, uri }) => {
               return (
                 <li key={id}>
                   {
-                    <Link href={`category/${name}`}>
+                    <Link href={uri ?? '#'}>
                       <a>{name}</a>
                     </Link>
                   }


### PR DESCRIPTION
There were a few cases of hardcoded paths originally, but this was the only one left.

**NOTE:** In order for category links to match our `pages` structure, you'll need to go into WordPress -> Permalinks and set your "Category base" to `category`. We'll need to include the `category_base` option in the blueprint once ACM ships option support for exports.

<img width="738" alt="Screen Shot 2022-03-17 at 3 56 52 PM" src="https://user-images.githubusercontent.com/4661832/158885099-5314607b-fbbe-41bf-bf60-bc0b821e2d3d.png">