### PR TITLE
Reduce footer social icon transition duration on hover

### DIFF
--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -50,13 +50,13 @@
         align-items: center;
         color: var(--color-white);
         background-color: transparent;
-        transition: background-color 0.5s ease-in-out;
+        transition: background-color 0.1s ease-in-out;
 
 
         .social-icon {
             color: var(--color-white);
             vertical-align: middle;
-            transition: color 0.5s ease-in-out;
+            transition: color 0.1s ease-in-out;
         }
     
         &:hover, &:focus {


### PR DESCRIPTION
Was originally `0.1` but was changed to `0.5` for testing at some point in time. Reverting the change in this PR.