### PR TITLE
Remove unused code

### DIFF
--- a/src/components/FeaturedImage/FeaturedImage.module.scss
+++ b/src/components/FeaturedImage/FeaturedImage.module.scss
@@ -3,7 +3,3 @@
   background-color: var(--color-white);
   filter: drop-shadow(0px 0px 50px rgba(0, 0, 0, 0.1));
 }
-
-.default-image {
-  min-width: 340px;
-}

--- a/src/components/Posts/Posts.js
+++ b/src/components/Posts/Posts.js
@@ -20,7 +20,6 @@ function Posts({ posts, intro, id }) {
                 <FeaturedImage
                   className={styles.image}
                   image={post?.featuredImage?.node}
-                  alt={post?.featuredImage?.node?.altText}
                   width={340}
                   height={340}
                 />

--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -18,7 +18,6 @@ function Projects({ projects, id, emptyText = 'No projects found.' }) {
               <FeaturedImage
                 className={styles.image}
                 image={project?.featuredImage?.node}
-                alt={project?.featuredImage?.node?.altText}
               />
               <div className={styles.content}>
                 <Heading level="h3">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -78,11 +78,7 @@ export default function Page() {
           <Heading className="text-center" level="h2">
             Latest Posts
           </Heading>
-          <Posts
-            posts={posts?.nodes}
-            readMoreText={'Read More'}
-            id="posts-list"
-          />
+          <Posts posts={posts?.nodes} id="posts-list" />
         </section>
         <section className="cta">
           <CTA


### PR DESCRIPTION
Removes a few unnecessary props and one CSS class.

- `readMoreText` isn't a supported prop of the [`Posts` component](https://github.com/wpengine/atlas-blueprint-portfolio/blob/39bbb799e5df14fafdff610f0963d9fc6891e889/src/components/Posts/Posts.js#L6).
- `.default-image` wasn't used anywhere.
- `alt` is unnecessary as the `FeaturedImage` component handles it automatically.