### PR TITLE
Prioritize featured image paint

### DIFF
--- a/src/components/FeaturedImage/FeaturedImage.js
+++ b/src/components/FeaturedImage/FeaturedImage.js
@@ -22,6 +22,7 @@ export default function FeaturedImage({ className, image, ...props }) {
         alt={altText}
         objectFit="contain"
         layout="responsive"
+        priority
         {...props}
       />
     </figure>

--- a/src/components/FeaturedImage/FeaturedImage.js
+++ b/src/components/FeaturedImage/FeaturedImage.js
@@ -22,7 +22,6 @@ export default function FeaturedImage({ className, image, ...props }) {
         alt={altText}
         objectFit="contain"
         layout="responsive"
-        priority
         {...props}
       />
     </figure>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -74,7 +74,7 @@ export default function Header({ title, image, date, author }) {
       {image && (
         <div className={styles['image']}>
           <div className="container">
-            <FeaturedImage className={styles['featured-image']} image={image} />
+            <FeaturedImage className={styles['featured-image']} image={image} priority />
           </div>
         </div>
       )}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -74,7 +74,11 @@ export default function Header({ title, image, date, author }) {
       {image && (
         <div className={styles['image']}>
           <div className="container">
-            <FeaturedImage className={styles['featured-image']} image={image} priority />
+            <FeaturedImage
+              className={styles['featured-image']}
+              image={image}
+              priority
+            />
           </div>
         </div>
       )}


### PR DESCRIPTION
This change applies the Next recommendation of prioritizing above the fold images.

https://nextjs.org/docs/api-reference/next/image#priority

<img width="983" alt="Screen Shot 2022-03-22 at 3 31 47 PM" src="https://user-images.githubusercontent.com/6676674/159561673-512a194f-95a5-4116-aeaa-1e064ca57013.png">