### PR TITLE
Create `<SEO>` component for an easy SEO abstraction

### DIFF
--- a/src/components/SEO/SEO.js
+++ b/src/components/SEO/SEO.js
@@ -1,0 +1,56 @@
+import Head from 'next/head';
+
+/**
+ * Provide SEO related meta tags to a page.
+ *
+ * @param {Props} props The props object.
+ * @param {string} props.title Used for the page title, og:title, twitter:title, etc.
+ * @param {string} props.description Used for the meta description, og:description, twitter:description, etc.
+ * @param {string} props.imageUrl Used for the og:image and twitter:image.
+ * @param {string} props.url Used for the og:url and twitter:url.
+ *
+ * @returns {React.ReactElement} The SEO component
+ */
+export default function SEO({ title, description, imageUrl, url }) {
+  if (!title || !description || !imageUrl || !url) {
+    return null;
+  }
+
+  return (
+    <Head>
+      <meta property="og:type" content="website" />
+      <meta property="twitter:card" content="summary_large_image" />
+
+      {title && (
+        <>
+          <title>{title}</title>
+          <meta name="title" content={title} />
+          <meta property="og:title" content={title} />
+          <meta property="twitter:title" content={title} />
+        </>
+      )}
+
+      {description && (
+        <>
+          <meta name="description" content={description} />
+          <meta property="og:description" content={description} />
+          <meta property="twitter:description" content={description} />
+        </>
+      )}
+
+      {imageUrl && (
+        <>
+          <meta property="og:image" content={imageUrl} />
+          <meta property="twitter:image" content={imageUrl} />
+        </>
+      )}
+
+      {url && (
+        <>
+          <meta property="og:url" content={url} />
+          <meta property="twitter:url" content={url} />
+        </>
+      )}
+    </Head>
+  );
+}

--- a/src/components/SEO/SEO.js
+++ b/src/components/SEO/SEO.js
@@ -12,45 +12,47 @@ import Head from 'next/head';
  * @returns {React.ReactElement} The SEO component
  */
 export default function SEO({ title, description, imageUrl, url }) {
-  if (!title || !description || !imageUrl || !url) {
+  if (!title && !description && !imageUrl && !url) {
     return null;
   }
 
   return (
-    <Head>
-      <meta property="og:type" content="website" />
-      <meta property="twitter:card" content="summary_large_image" />
+    <>
+      <Head>
+        <meta property="og:type" content="website" />
+        <meta property="twitter:card" content="summary_large_image" />
 
-      {title && (
-        <>
-          <title>{title}</title>
-          <meta name="title" content={title} />
-          <meta property="og:title" content={title} />
-          <meta property="twitter:title" content={title} />
-        </>
-      )}
+        {title && (
+          <>
+            <title>{title}</title>
+            <meta name="title" content={title} />
+            <meta property="og:title" content={title} />
+            <meta property="twitter:title" content={title} />
+          </>
+        )}
 
-      {description && (
-        <>
-          <meta name="description" content={description} />
-          <meta property="og:description" content={description} />
-          <meta property="twitter:description" content={description} />
-        </>
-      )}
+        {description && (
+          <>
+            <meta name="description" content={description} />
+            <meta property="og:description" content={description} />
+            <meta property="twitter:description" content={description} />
+          </>
+        )}
 
-      {imageUrl && (
-        <>
-          <meta property="og:image" content={imageUrl} />
-          <meta property="twitter:image" content={imageUrl} />
-        </>
-      )}
+        {imageUrl && (
+          <>
+            <meta property="og:image" content={imageUrl} />
+            <meta property="twitter:image" content={imageUrl} />
+          </>
+        )}
 
-      {url && (
-        <>
-          <meta property="og:url" content={url} />
-          <meta property="twitter:url" content={url} />
-        </>
-      )}
-    </Head>
+        {url && (
+          <>
+            <meta property="og:url" content={url} />
+            <meta property="twitter:url" content={url} />
+          </>
+        )}
+      </Head>
+    </>
   );
 }

--- a/src/components/SEO/index.js
+++ b/src/components/SEO/index.js
@@ -1,0 +1,3 @@
+import SEO from './SEO';
+
+export default SEO;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -20,6 +20,7 @@ import SearchRecommendations from './SearchRecommendations';
 import NextLinkWrapper from './NextLinkWrapper';
 import LoadingSearchResult from './LoadingSearchResult';
 import TaxonomyTerms from './TaxonomyTerms';
+import SEO from './SEO';
 
 export {
   Posts,
@@ -44,4 +45,5 @@ export {
   SearchRecommendations,
   NextLinkWrapper,
   LoadingSearchResult,
+  SEO,
 };

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { client } from 'client';
-import Head from 'next/head';
-import { Footer, Header, Main } from 'components';
+import { Footer, Header, Main, SEO } from 'components';
 
 export default function Page() {
   const { useQuery } = client;
@@ -9,11 +8,9 @@ export default function Page() {
 
   return (
     <>
-      <Head>
-        <title>
-          {generalSettings?.title} - {generalSettings?.description}
-        </title>
-      </Head>
+      <SEO
+        title={`${generalSettings?.title} - ${generalSettings?.description}`}
+      />
 
       <Header title="404: Not Found" />
 

--- a/src/pages/[...pageUri].js
+++ b/src/pages/[...pageUri].js
@@ -1,7 +1,6 @@
 import { getNextStaticProps, is404 } from '@faustjs/next';
-import Head from 'next/head';
 import { client } from 'client';
-import { Header, ContentWrapper, Footer, Main } from 'components';
+import { Header, ContentWrapper, Footer, Main, SEO } from 'components';
 
 export function PageComponent({ page }) {
   const { useQuery } = client;
@@ -9,11 +8,11 @@ export function PageComponent({ page }) {
 
   return (
     <>
-      <Head>
-        <title>
-          {page?.title()} - {generalSettings?.title}
-        </title>
-      </Head>
+      <SEO
+        title={`${page?.title()} - ${generalSettings?.title}`}
+        imageUrl={page?.featuredImage?.node?.sourceUrl?.()}
+      />
+
       <Header title={page?.title()} image={page?.featuredImage?.node} />
 
       <Main className="container">

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -16,7 +16,7 @@ class MyDocument extends Document {
             rel="stylesheet"
           />
         </Head>
-        <body className="theme-blue">
+        <body>
           <Main />
           <NextScript />
         </body>

--- a/src/pages/category/[categorySlug]/index.js
+++ b/src/pages/category/[categorySlug]/index.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { getNextStaticProps, is404 } from '@faustjs/next';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { client } from 'client';
-import { Posts, Heading, LoadMore, Footer, Main, Header } from 'components';
+import { Posts, LoadMore, Footer, Main, Header, SEO } from 'components';
 import appConfig from 'app.config';
 import usePagination from 'hooks/usePagination';
 
@@ -32,9 +31,7 @@ export default function Page() {
   );
   return (
     <>
-      <Head>
-        <title>Posts - {generalSettings?.title}</title>
-      </Head>
+      <SEO title={`Posts - ${generalSettings?.title}`} />
 
       <Header title={`Category: ${category?.name}`} />
 

--- a/src/pages/category/index.js
+++ b/src/pages/category/index.js
@@ -1,8 +1,7 @@
 import { getNextStaticProps, is404 } from '@faustjs/next';
-import Head from 'next/head';
 import Link from 'next/link';
 import { client } from 'client';
-import { Footer, Header, Main } from 'components';
+import { Footer, Header, Main, SEO } from 'components';
 
 export default function Page() {
   const { useQuery } = client;
@@ -15,9 +14,7 @@ export default function Page() {
 
   return (
     <>
-      <Head>
-        <title>All Categories - {generalSettings?.title}</title>
-      </Head>
+      <SEO title={`All Categories - ${generalSettings?.title}`} />
 
       <Header title="All Categories" />
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,4 @@
 import { getNextStaticProps } from '@faustjs/next';
-import Head from 'next/head';
 import React from 'react';
 import { client } from 'client';
 import { FaArrowRight } from 'react-icons/fa';
@@ -12,6 +11,7 @@ import {
   Heading,
   CTA,
   Testimonials,
+  SEO,
 } from 'components';
 import styles from 'styles/pages/_Home.module.scss';
 
@@ -35,11 +35,11 @@ export default function Page() {
 
   return (
     <>
-      <Head>
-        <title>
-          {generalSettings?.title} - {generalSettings?.description}
-        </title>
-      </Head>
+      <SEO
+        title={`${generalSettings?.title} - ${generalSettings?.description}`}
+        imageUrl={mainBanner?.sourceUrl}
+      />
+
       <Header image={mainBanner} />
 
       <Main className={[styles.home, 'container'].join(' ')}>

--- a/src/pages/posts/[postSlug]/index.js
+++ b/src/pages/posts/[postSlug]/index.js
@@ -5,9 +5,9 @@ import {
   Footer,
   Header,
   Main,
+  SEO,
   TaxonomyTerms,
 } from 'components';
-import Head from 'next/head';
 
 export function PostComponent({ post }) {
   const { useQuery } = client;
@@ -15,11 +15,10 @@ export function PostComponent({ post }) {
 
   return (
     <>
-      <Head>
-        <title>
-          {post?.title()} - {generalSettings?.title}
-        </title>
-      </Head>
+      <SEO
+        title={`${post?.title()} - ${generalSettings?.title}`}
+        imageUrl={post?.featuredImage?.node?.sourceUrl?.()}
+      />
 
       <Header
         title={post?.title()}

--- a/src/pages/posts/index.js
+++ b/src/pages/posts/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { getNextStaticProps } from '@faustjs/next';
 import { client } from 'client';
-import Head from 'next/head';
-import { Posts, Header, LoadMore, Footer, Main } from 'components';
+import { Posts, Header, LoadMore, Footer, Main, SEO } from 'components';
 import usePagination from 'hooks/usePagination';
 import appConfig from '../../app.config';
 
@@ -25,9 +24,7 @@ export default function Page() {
 
   return (
     <>
-      <Head>
-        <title>All Posts - {generalSettings?.description}</title>
-      </Head>
+      <SEO title={`All Posts - ${generalSettings?.description}`} />
 
       <Header title="Latest Posts" />
 

--- a/src/pages/projects/[projectSlug]/index.js
+++ b/src/pages/projects/[projectSlug]/index.js
@@ -6,6 +6,7 @@ import {
   ProjectHeader,
   ContentWrapper,
   Main,
+  SEO,
 } from 'components';
 import Head from 'next/head';
 
@@ -15,11 +16,10 @@ export function ProjectComponent({ project }) {
 
   return (
     <>
-      <Head>
-        <title>
-          {project?.title()} - {generalSettings?.title}
-        </title>
-      </Head>
+      <SEO
+        title={`${project?.title()} - ${generalSettings?.title}`}
+        imageUrl={project?.featuredImage?.node?.sourceUrl?.()}
+      />
 
       <Header title={project?.title()} />
 

--- a/src/pages/projects/index.js
+++ b/src/pages/projects/index.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import Head from 'next/head';
 import { client } from 'client';
 import appConfig from 'app.config';
 import usePagination from 'hooks/usePagination';
-import { Footer, Header, LoadMore, Main, Projects } from 'components';
+import { Footer, Header, LoadMore, Main, Projects, SEO } from 'components';
 import { getNextStaticProps } from '@faustjs/next';
 
 export default function Page() {
@@ -26,11 +25,7 @@ export default function Page() {
 
   return (
     <>
-      <Head>
-        <title>
-          {generalSettings?.title} - {generalSettings?.description}
-        </title>
-      </Head>
+      <SEO title={`Portfolio - ${generalSettings?.description}`} />
 
       <Header title="Portfolio" />
 

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -8,9 +8,9 @@ import {
   SearchInput,
   SearchRecommendations,
   SearchResults,
+  SEO,
 } from 'components';
 import useSearch from 'hooks/useSearch';
-import Head from 'next/head';
 import React from 'react';
 import styles from 'styles/pages/_Search.module.scss';
 
@@ -29,9 +29,7 @@ export default function Page() {
 
   return (
     <>
-      <Head>
-        <title>Search - {generalSettings?.description}</title>
-      </Head>
+      <SEO title={`Search - ${generalSettings?.description}`} />
 
       <Header className={styles['search-header']} />
 


### PR DESCRIPTION
This PR introduces a new `<SEO>` component as an abstraction to automatically populate important meta tags for SEO based on the provided props.