### PR TITLE
Fix filter drop shadow quirk

### DIFF
--- a/src/components/CTA/CTA.module.scss
+++ b/src/components/CTA/CTA.module.scss
@@ -10,7 +10,7 @@
   padding: 6rem;
   border: 2rem solid #fff;
   color: #fff;
-  filter: $filter-drop-shadow;
+  box-shadow: $box-shadow;
 
   @media (min-width: $breakpoint-small) {
     flex-direction: row;

--- a/src/components/FeaturedImage/FeaturedImage.module.scss
+++ b/src/components/FeaturedImage/FeaturedImage.module.scss
@@ -3,5 +3,5 @@
 .featured-image {
   border: 2rem solid var(--color-white);
   background-color: var(--color-white);
-  filter: $filter-drop-shadow;
+  box-shadow: $box-shadow;
 }

--- a/src/pages/projects/[projectSlug]/index.js
+++ b/src/pages/projects/[projectSlug]/index.js
@@ -8,7 +8,6 @@ import {
   Main,
   SEO,
 } from 'components';
-import Head from 'next/head';
 
 export function ProjectComponent({ project }) {
   const { useQuery } = client;

--- a/src/styles/_Variables.scss
+++ b/src/styles/_Variables.scss
@@ -10,4 +10,4 @@ $grid-max-width: 62rem;
 $container-max-width: 102.4rem;
 $container-max-width-sm: 60rem;
 
-$filter-drop-shadow: drop-shadow(0px 0px 50px rgba(0, 0, 0, 0.1));
+$box-shadow: 0px 0px 50px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
I've been experiencing an odd quirk with the drop shadow filter. Especially after loading more posts.

My assumption is since drop shadow doesn't follow the box model, and post images may have not been fetched yet, it is creating this weird shadow effect:

<img width="1792" alt="Screen Shot 2022-03-23 at 12 18 22 PM" src="https://user-images.githubusercontent.com/5946219/159760158-4fc5d28b-35b7-4308-9fec-61d90506abdc.png">

Switching to a `box-shadow` seems to have fixed this.
