### PR TITLE
Rename Button `type` Prop

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -7,29 +7,32 @@ import styles from './Button.module.scss';
  *
  * @param {Props} props The props object.
  * @param {string} props.href The href attribute. If provided the button will be an <a> element.
- * @param {primary|secondary} props.type The type of the button
+ * @param {primary|secondary} props.styleType The type of the button
  * @param {string} props.className An optional className to be added to the button
  * @return {React.ReactElement} The Button component.
  */
-export default function Button({ href, type, className, children, ...props }) {
-  let buttonType;
-  switch (type) {
-    case 'primary': {
-      buttonType = 'primary';
-      break;
-    }
+export default function Button({
+  href,
+  styleType,
+  className,
+  children,
+  ...props
+}) {
+  let buttonStyle;
+  switch (styleType) {
     case 'secondary': {
-      buttonType = 'secondary';
+      buttonStyle = 'secondary';
       break;
     }
     default: {
-      buttonType = 'primary';
+      buttonStyle = 'primary';
+      break;
     }
   }
 
   let buttonClassName = [
     styles.button,
-    styles[`button-${buttonType}`],
+    styles[`button-${buttonStyle}`],
     className ?? undefined,
   ].join(' ');
 
@@ -44,7 +47,7 @@ export default function Button({ href, type, className, children, ...props }) {
   }
 
   return (
-    <button type="button" className={buttonClassName} {...props}>
+    <button className={buttonClassName} {...props}>
       {children}
     </button>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,10 +52,10 @@ export default function Page() {
             world&apos;s #1 open source CMS in one powerful headless platform.{' '}
           </p>
           <div className={styles.actions}>
-            <Button type="secondary" href="#">
+            <Button styleType="secondary" href="#">
               GET STARTED
             </Button>
-            <Button type="primary" href="#">
+            <Button styleType="primary" href="#">
               LEARN MORE
             </Button>
           </div>


### PR DESCRIPTION
This PR renames the `<Buton>` component `type` prop to `styleType` to allow for the users to do something like:

```jsx
<Button styleType="secondary" type="submit">Search</Button>
```