### PR TITLE
Fix multiple GraphQL requests on "load more"

### DIFF
--- a/src/components/LoadMore/LoadMore.js
+++ b/src/components/LoadMore/LoadMore.js
@@ -4,12 +4,13 @@ import React from 'react';
 import styles from './LoadMore.module.scss';
 
 export default function LoadMore({
-  pageInfo,
+  hasNextPage,
+  endCursor,
   isLoading,
   fetchMore,
   className,
 }) {
-  if (pageInfo?.hasNextPage && pageInfo?.endCursor) {
+  if (hasNextPage && endCursor) {
     return (
       <section className={className}>
         <button
@@ -18,7 +19,7 @@ export default function LoadMore({
           onClick={() => {
             fetchMore({
               first: appConfig.postsPerPage,
-              after: pageInfo?.endCursor,
+              after: endCursor,
             });
           }}
         >

--- a/src/hooks/useNodePagination.js
+++ b/src/hooks/useNodePagination.js
@@ -31,7 +31,7 @@ export const defaultProjectPrepassItems = [
 ];
 
 /**
- * The `usePostPagination` hook is an abstraction of the `usePaginatedQuery` from GQty that enables
+ * The `useNodePagination` hook is an abstraction of the `usePaginatedQuery` from GQty that enables
  * you to specify a query to get nodes and page info, and will fetch those initial items, as well
  * as provide a mechanism to fetch more.
  *
@@ -39,7 +39,7 @@ export const defaultProjectPrepassItems = [
  * @param {array|undefined} prepassItems Optional: An array of items to pass to the `prepass()` GQty helper function.
  * @returns
  */
-export default function usePostPagination(queryFn, prepassItems) {
+export default function useNodePagination(queryFn, prepassItems) {
   const queryFnRef = useRef(queryFn);
 
   /**

--- a/src/hooks/usePostPagination.js
+++ b/src/hooks/usePostPagination.js
@@ -9,7 +9,7 @@ import { useRef } from 'react';
  *
  * @see https://gqty.dev/docs/client/helper-functions#prepass
  */
-export const defaultPrepassItems = [
+export const defaultPostPrepassItems = [
   'databaseId',
   'id',
   '__typename',
@@ -22,6 +22,12 @@ export const defaultPrepassItems = [
   'date',
   'uri',
   'title',
+  'slug',
+];
+
+export const defaultProjectPrepassItems = [
+  ...defaultPostPrepassItems,
+  'summary',
 ];
 
 /**
@@ -30,19 +36,11 @@ export const defaultPrepassItems = [
  * as provide a mechanism to fetch more.
  *
  * @param {(query, queryArgs) => Function} queryFn The query function to get your `nodes` and `pageInfo`.'
- * @param {object|undefined} initialQueryArgs Optional: The initial query args used to fetch the initial post.
  * @param {array|undefined} prepassItems Optional: An array of items to pass to the `prepass()` GQty helper function.
  * @returns
  */
-export default function usePostPagination(
-  queryFn,
-  initialQueryArgs,
-  prepassItems
-) {
+export default function usePostPagination(queryFn, prepassItems) {
   const queryFnRef = useRef(queryFn);
-  const initialArgs = initialQueryArgs ?? {
-    first: appConfig?.postsPerPage,
-  };
 
   /**
    * Use the `usePaginatedQuery` from GQty to fetch the initial posts and
@@ -62,7 +60,7 @@ export default function usePostPagination(
        * If there was user defined prepassItems use them.
        * Otherwise, use the defaults.
        */
-      let prepassList = prepassItems ?? defaultPrepassItems;
+      let prepassList = prepassItems ?? defaultPostPrepassItems;
 
       /**
        * Do a prepass for the data requirements we need so all data
@@ -82,7 +80,9 @@ export default function usePostPagination(
       /**
        * Required, only used for the first fetch
        */
-      initialArgs,
+      initialArgs: {
+        first: appConfig?.postsPerPage,
+      },
       /**
        * Optional merge function
        */

--- a/src/hooks/usePostPagination.js
+++ b/src/hooks/usePostPagination.js
@@ -1,0 +1,103 @@
+import appConfig from 'app.config';
+import { client } from 'client';
+import { useRef } from 'react';
+
+/**
+ * Default prepass items for posts. This lists all the pieces of data we need
+ * for each post node. Running the following through `prepass` ensures that
+ * all of the data is there when we need it, and no cascading requests happen.
+ *
+ * @see https://gqty.dev/docs/client/helper-functions#prepass
+ */
+export const defaultPrepassItems = [
+  'databaseId',
+  'id',
+  '__typename',
+  'featuredImage.*',
+  'featuredImage.node.altText',
+  'featuredImage.node.mediaDetails.width',
+  'featuredImage.node.mediaDetails.height',
+  'featuredImage.node.sourceUrl',
+  'author.node.name',
+  'date',
+  'uri',
+  'title',
+];
+
+/**
+ * The `usePostPagination` hook is an abstraction of the `usePaginatedQuery` from GQty that enables
+ * you to specify a query to get nodes and page info, and will fetch those initial items, as well
+ * as provide a mechanism to fetch more.
+ *
+ * @param {(query, queryArgs) => Function} queryFn The query function to get your `nodes` and `pageInfo`.'
+ * @param {object|undefined} initialQueryArgs Optional: The initial query args used to fetch the initial post.
+ * @param {array|undefined} prepassItems Optional: An array of items to pass to the `prepass()` GQty helper function.
+ * @returns
+ */
+export default function usePostPagination(
+  queryFn,
+  initialQueryArgs,
+  prepassItems
+) {
+  const queryFnRef = useRef(queryFn);
+  const initialArgs = initialQueryArgs ?? {
+    first: appConfig?.postsPerPage,
+  };
+
+  /**
+   * Use the `usePaginatedQuery` from GQty to fetch the initial posts and
+   * create a `fetchMore` method that can be used to fetch more posts.
+   *
+   * @see https://gqty.dev/docs/react/fetching-data#usepaginatedquery
+   */
+  const { data, fetchMore, isLoading } = client.usePaginatedQuery(
+    (query, input, { prepass }) => {
+      /**
+       * Call the query function provided as an argument to get the appropriate
+       * nodes and page info.
+       */
+      const res = queryFnRef.current(query, input);
+
+      /**
+       * If there was user defined prepassItems use them.
+       * Otherwise, use the defaults.
+       */
+      let prepassList = prepassItems ?? defaultPrepassItems;
+
+      /**
+       * Do a prepass for the data requirements we need so all data
+       * will be fetched in one request and no chance for cascading.
+       *
+       * @see https://gqty.dev/docs/client/helper-functions#prepass
+       */
+      prepass(res?.nodes, ...prepassList);
+
+      return {
+        nodes: res?.nodes,
+        hasNextPage: res?.pageInfo?.hasNextPage,
+        endCursor: res?.pageInfo?.endCursor,
+      };
+    },
+    {
+      /**
+       * Required, only used for the first fetch
+       */
+      initialArgs,
+      /**
+       * Optional merge function
+       */
+      merge({ data: { existing, incoming }, uniqBy }) {
+        if (existing) {
+          return {
+            ...incoming,
+            // If using 'cache-and-network', you have to use `uniqBy`
+            nodes: uniqBy([...existing.nodes, ...incoming.nodes], (v) => v.id),
+          };
+        }
+        return incoming;
+      },
+    }
+  );
+
+  return { data, fetchMore, isLoading };
+}

--- a/src/pages/category/[categorySlug]/index.js
+++ b/src/pages/category/[categorySlug]/index.js
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import { client } from 'client';
 import { Posts, LoadMore, Footer, Main, Header, SEO } from 'components';
 import { pageTitle } from 'utils';
-import usePostPagination from 'hooks/usePostPagination';
+import useNodePagination from 'hooks/useNodePagination';
 
 export default function Page() {
   const { useQuery, useCategory } = client;
@@ -13,7 +13,7 @@ export default function Page() {
   const generalSettings = useQuery().generalSettings;
   const category = useCategory();
 
-  const { data, fetchMore, isLoading } = usePostPagination(
+  const { data, fetchMore, isLoading } = useNodePagination(
     (query, queryArgs) => {
       return query.posts({
         ...queryArgs,

--- a/src/pages/category/[categorySlug]/index.js
+++ b/src/pages/category/[categorySlug]/index.js
@@ -3,33 +3,25 @@ import { getNextStaticProps, is404 } from '@faustjs/next';
 import { useRouter } from 'next/router';
 import { client } from 'client';
 import { Posts, LoadMore, Footer, Main, Header, SEO } from 'components';
-import appConfig from 'app.config';
-import usePagination from 'hooks/usePagination';
 import { pageTitle } from 'utils';
+import usePostPagination from 'hooks/usePostPagination';
 
 export default function Page() {
-  const { useQuery, usePosts, useCategory } = client;
+  const { useQuery, useCategory } = client;
   const { query = {} } = useRouter();
   const { categorySlug } = query;
   const generalSettings = useQuery().generalSettings;
   const category = useCategory();
-  const posts = usePosts({
-    first: appConfig.postsPerPage,
-    where: {
-      categoryName: categorySlug,
-    },
-  });
 
-  const { data, fetchMore, isLoading } = usePagination(
-    (query, args) => {
-      const { nodes, pageInfo } = query.posts(args);
-      return {
-        nodes: Array.from(nodes),
-        pageInfo,
-      };
-    },
-    { nodes: posts?.nodes, pageInfo: posts?.pageInfo }
+  const { data, fetchMore, isLoading } = usePostPagination(
+    (query, queryArgs) => {
+      return query.posts({
+        ...queryArgs,
+        where: { categoryName: categorySlug },
+      });
+    }
   );
+
   return (
     <>
       <SEO
@@ -39,10 +31,11 @@ export default function Page() {
       <Header title={`Category: ${category?.name}`} />
 
       <Main className="container">
-        <Posts posts={data.nodes} />
+        <Posts posts={data?.nodes} />
         <LoadMore
           className="text-center"
-          pageInfo={data.pageInfo}
+          hasNextPage={data?.hasNextPage}
+          endCursor={data?.endCursor}
           isLoading={isLoading}
           fetchMore={fetchMore}
         />

--- a/src/pages/posts/index.js
+++ b/src/pages/posts/index.js
@@ -3,12 +3,12 @@ import { getNextStaticProps } from '@faustjs/next';
 import { client } from 'client';
 import { Posts, Header, LoadMore, Footer, Main, SEO } from 'components';
 import { pageTitle } from 'utils';
-import usePostPagination from 'hooks/usePostPagination';
+import useNodePagination from 'hooks/useNodePagination';
 
 export default function Page() {
   const { useQuery } = client;
   const generalSettings = useQuery().generalSettings;
-  const { data, fetchMore, isLoading } = usePostPagination((query, queryArgs) =>
+  const { data, fetchMore, isLoading } = useNodePagination((query, queryArgs) =>
     query.posts(queryArgs)
   );
 

--- a/src/pages/posts/index.js
+++ b/src/pages/posts/index.js
@@ -2,25 +2,14 @@ import React from 'react';
 import { getNextStaticProps } from '@faustjs/next';
 import { client } from 'client';
 import { Posts, Header, LoadMore, Footer, Main, SEO } from 'components';
-import usePagination from 'hooks/usePagination';
-import appConfig from 'app.config';
 import { pageTitle } from 'utils';
+import usePostPagination from 'hooks/usePostPagination';
 
 export default function Page() {
-  const { useQuery, usePosts } = client;
-  const posts = usePosts({
-    first: appConfig.postsPerPage,
-  });
+  const { useQuery } = client;
   const generalSettings = useQuery().generalSettings;
-  const { data, fetchMore, isLoading } = usePagination(
-    (query, args) => {
-      const { nodes, pageInfo } = query.posts(args);
-      return {
-        nodes: Array.from(nodes),
-        pageInfo,
-      };
-    },
-    { nodes: posts?.nodes, pageInfo: posts?.pageInfo }
+  const { data, fetchMore, isLoading } = usePostPagination((query, queryArgs) =>
+    query.posts(queryArgs)
   );
 
   return (
@@ -33,7 +22,8 @@ export default function Page() {
         <Posts posts={data?.nodes} readMoreText="Read More" id="posts-list" />
         <LoadMore
           className="text-center"
-          pageInfo={data.pageInfo}
+          hasNextPage={data?.hasNextPage}
+          endCursor={data?.endCursor}
           isLoading={isLoading}
           fetchMore={fetchMore}
         />

--- a/src/pages/projects/index.js
+++ b/src/pages/projects/index.js
@@ -1,27 +1,18 @@
 import React from 'react';
 import { client } from 'client';
-import appConfig from 'app.config';
-import usePagination from 'hooks/usePagination';
 import { Footer, Header, LoadMore, Main, Projects, SEO } from 'components';
 import { getNextStaticProps } from '@faustjs/next';
 import { pageTitle } from 'utils';
+import usePostPagination, {
+  defaultProjectPrepassItems,
+} from 'hooks/usePostPagination';
 
 export default function Page() {
   const { useQuery } = client;
   const generalSettings = useQuery().generalSettings;
-  const projects = useQuery().projects({
-    first: appConfig.postsPerPage,
-  });
-
-  const { data, fetchMore, isLoading } = usePagination(
-    (query, args) => {
-      const { nodes, pageInfo } = query.projects(args);
-      return {
-        nodes: Array.from(nodes),
-        pageInfo,
-      };
-    },
-    { nodes: projects?.nodes, pageInfo: projects?.pageInfo }
+  const { data, fetchMore, isLoading } = usePostPagination(
+    (query, queryArgs) => query.projects(queryArgs),
+    defaultProjectPrepassItems
   );
 
   return (
@@ -31,9 +22,10 @@ export default function Page() {
       <Header title="Portfolio" />
 
       <Main className="container">
-        <Projects projects={data.nodes} id="portfolio-list" />
+        <Projects projects={data?.nodes} id="portfolio-list" />
         <LoadMore
-          pageInfo={data.pageInfo}
+          hasNextPage={data?.hasNextPage}
+          endCursor={data?.endCursor}
           isLoading={isLoading}
           fetchMore={fetchMore}
           className="text-center"

--- a/src/pages/projects/index.js
+++ b/src/pages/projects/index.js
@@ -3,14 +3,14 @@ import { client } from 'client';
 import { Footer, Header, LoadMore, Main, Projects, SEO } from 'components';
 import { getNextStaticProps } from '@faustjs/next';
 import { pageTitle } from 'utils';
-import usePostPagination, {
+import useNodePagination, {
   defaultProjectPrepassItems,
-} from 'hooks/usePostPagination';
+} from 'hooks/useNodePagination';
 
 export default function Page() {
   const { useQuery } = client;
   const generalSettings = useQuery().generalSettings;
-  const { data, fetchMore, isLoading } = usePostPagination(
+  const { data, fetchMore, isLoading } = useNodePagination(
     (query, queryArgs) => query.projects(queryArgs),
     defaultProjectPrepassItems
   );


### PR DESCRIPTION
This PR introduces a new hook called `useNodePagination` for loading more. This takes most from what @theodesp has created in `src/hooks/usePagination.js`, but adds some modifications like using `prepass` because.... GQty 😅 

This PR has some opinions (like defining prepass items), so please let me know what you think. We may want to just stick with @theodesp original work if these constrains are not worth it.