### PR TITLE
Move `is404Cpt` into `utils`

### DIFF
--- a/src/pages/projects/[projectSlug]/index.js
+++ b/src/pages/projects/[projectSlug]/index.js
@@ -9,6 +9,7 @@ import {
   Main,
   SEO,
 } from 'components';
+import { is404Cpt } from 'utils';
 
 export function ProjectComponent({ project }) {
   const { useQuery } = client;
@@ -68,22 +69,4 @@ export function getStaticPaths() {
     paths: [],
     fallback: 'blocking',
   };
-}
-
-/**
- * Checks if a post is available given a custom post type.
- * Temporary until Faust's is404() is adjusted to account for custom post types.
- * @param {string} slug The slug of the custom post type.
- * @param {string} customPostType The WordPress custom post type.
- * @returns {bool}
- */
-async function is404Cpt(slug, customPostType) {
-  const customPostTypePost = await client.client.inlineResolved(() => {
-    return client.client.query[customPostType]({
-      id: slug,
-      idType: 'SLUG',
-    });
-  });
-
-  return customPostTypePost === null;
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 import uniqBy from './uniqBy';
 import pageTitle from './pageTitle';
+import is404Cpt from './is404Cpt';
 
-export { uniqBy, pageTitle };
+export { uniqBy, pageTitle, is404Cpt };

--- a/src/utils/is404Cpt.js
+++ b/src/utils/is404Cpt.js
@@ -1,0 +1,22 @@
+import { selectFields } from 'gqty';
+import { client } from 'client';
+
+/**
+ * Checks if a post is available given a custom post type.
+ * Temporary until Faust's is404() is adjusted to account for custom post types.
+ * @param {string} slug The slug of the custom post type.
+ * @param {string} customPostType The WordPress custom post type.
+ * @returns {bool}
+ */
+export default async function is404Cpt(slug, customPostType) {
+  const customPostTypePost = await client.client.resolved(() => {
+    const node = client.client.query[customPostType]({
+      id: slug,
+      idType: 'SLUG',
+    });
+
+    return selectFields(node, ['id']);
+  });
+
+  return customPostTypePost === null;
+}


### PR DESCRIPTION
This PR moves `is404Cpt` into `utils`.

It also replaces `inlineResolved` for `resolved`, and uses `selectFields` to return an actual array, instead of the proxy.

## Testing

1. Without checking out this PR, visit a non existant project (http://localhost:3000/projects/1000). On the first visit, the page will not 404. On the second visit, the page will 404.
2. Check out this PR and visit a non existant project (http://localhost:3000/2424). This first visit, and subsequent visits, will result in a proper 404.