### PR TITLE
[MERL-206] feat(acm menus): add ACM Menus in blueprint export

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,5 +13,5 @@ This will import the ACM Blueprint export into your WordPress database. Make any
 ### Exporting
 
 1. Before exporting, make sure you have deleted any of the initial content that gets created upon a WordPress install (e.g. "Sample Page", "Hello World", any comments, etc.)
-2. From the WP CLI, run `wp acm blueprint export --open`. This will export the site into the appropriate ACM Blueprint .zip, and also open the location where the .zip was saved.
+2. From the WP CLI, run `wp acm blueprint export --open --wp-options=category_base,permalink_structure,nav_menu_options,theme_mods_twentytwentytwo --post-types=nav_menu_item,post,page,testimonial,project`. This will export the site into the appropriate ACM Blueprint .zip, and also open the location where the .zip was saved. It will also export the Navigational Menus and the CPTs from the ACM models.
 3. Replace the existing `acm-blueprint.zip` in the repo with the newly exported `acm-blueprint.zip` and make a PR with the changes.


### PR DESCRIPTION
## Description
Adds Navigational menus to `acm-blueprint.zip` export


## Testing

1. Make sure you create a fresh WP Install. Do not use WP Reset plugin or anything similar as it may not work.

2. Open a shell.
3. Import the blueprint:
```
wp acm blueprint import https://github.com/wpengine/atlas-blueprint-portfolio/raw/5a0186adb4120d90fe08f800494627e3e356b596/acm-blueprint.zip
```

## Reference

I used the following command to export the menus:

```
wp acm blueprint export --open --wp-options=category_base,permalink_structure,nav_menu_options --post-types=nav_menu_item,post,page,testimonial,project
```