### PR TITLE
[MERL-194] link styles

### DIFF
--- a/src/components/ContentWrapper/ContentWrapper.module.scss
+++ b/src/components/ContentWrapper/ContentWrapper.module.scss
@@ -29,8 +29,15 @@
     }
 
     a {
-      color: var(--color-black);
+      color: var(--color-secondary);
       text-decoration: underline;
+      transition: 0.2s background-color;
+
+      &:hover,
+      &:focus {
+        color: var(--color-secondary);
+        text-decoration: none;
+      }
     }
 
     li {
@@ -107,7 +114,7 @@
     }
 
     thead th {
-      border-bottom: 1px solid var(--color-secondary);
+      border-bottom: 1px solid var(--color-tertiary);
       padding-bottom: 0.5em;
     }
 
@@ -117,7 +124,7 @@
     }
 
     tr {
-      border-bottom: 1px solid var(--color-secondary);
+      border-bottom: 1px solid var(--color-tertiary);
     }
 
     td {

--- a/src/components/ContentWrapper/ContentWrapper.module.scss
+++ b/src/components/ContentWrapper/ContentWrapper.module.scss
@@ -3,6 +3,7 @@
 .content {
   max-width: $grid-max-width;
   margin: 0 auto;
+  line-height: 1.6875;
 
   :global {
     * {

--- a/src/components/ThemeStyles/ThemeStyles.js
+++ b/src/components/ThemeStyles/ThemeStyles.js
@@ -4,23 +4,23 @@ const themes = {
   blue: {
     '--color-black': '#000',
     '--color-primary': '#000066',
-    '--color-secondary': '#cccccc',
-    '--color-tertiary': '#eeeeee',
-    '--color-white': '#ffffff',
+    '--color-secondary': '#0969da',
+    '--color-tertiary': '#CCCCCC',
+    '--color-white': '#FFFFFF',
   },
   red: {
     '--color-black': '#000',
     '--color-primary': '#660000',
-    '--color-secondary': '#CCCCCC',
-    '--color-tertiary': '#EEEEEE',
-    '--color-white': '#fff',
+    '--color-secondary': '#B50505',
+    '--color-tertiary': '#CCCCCC',
+    '--color-white': '#FFFFFF',
   },
   green: {
     '--color-black': '#000',
     '--color-primary': '#006600',
-    '--color-secondary': '#CCCCCC',
-    '--color-tertiary': '#EEEEEE',
-    '--color-white': '#fff',
+    '--color-secondary': '#006827',
+    '--color-tertiary': '#CCCCCC',
+    '--color-white': '#FFFFFF',
   },
 };
 

--- a/src/styles/_Variables.scss
+++ b/src/styles/_Variables.scss
@@ -1,5 +1,5 @@
 $font-family: Inter, Verdana, Arial, Helvetica, sans-serif;
-$font-weight-normal: 300;
+$font-weight-normal: 400;
 $font-weight-bold: 600;
 $font-weight-extra-bold: 700;
 


### PR DESCRIPTION
Went with the same hover pattern as our blog. https://wpengine.com/blog/wp-engine-stands-with-ukraine/

Link underlines by default with no underline on hover/focus.

Since I opted to use theme colors, I adjusted them slightly to optimize legibility as the darker colors were getting lost against the black text.