### PR TITLE
Improve container responsiveness

### DIFF
--- a/src/components/ContentWrapper/ContentWrapper.module.scss
+++ b/src/components/ContentWrapper/ContentWrapper.module.scss
@@ -1,7 +1,7 @@
 @import 'styles/Variables';
 
 .content {
-  max-width: $grid-max-width;
+  max-width: $content-max-width;
   margin: 0 auto;
   line-height: 1.6875;
 

--- a/src/styles/_Grid.scss
+++ b/src/styles/_Grid.scss
@@ -17,7 +17,7 @@
 
 @media (min-width: $breakpoint-medium) {
   .container {
-    width: (10/12) * 100%;
+    width: percentage(10/12);
   }
 }
 

--- a/src/styles/_Grid.scss
+++ b/src/styles/_Grid.scss
@@ -5,13 +5,19 @@
 
 .container {
   margin: 0 auto;
-  max-width: $grid-max-width;
+  max-width: $container-max-width;
   padding: 0 2rem;
   position: relative;
   width: 100%;
 
   &.small {
-    max-width: $container-max-width-sm;
+    max-width: $content-max-width;
+  }
+}
+
+@media (min-width: $breakpoint-medium) {
+  .container {
+    width: (10/12) * 100%;
   }
 }
 
@@ -177,24 +183,6 @@
     .column-center {
       align-self: center;
     }
-  }
-}
-
-@media (min-width: 102.5rem) {
-  .container {
-    max-width: 120rem;
-  }
-}
-
-@media (max-width: 102.4rem) {
-  .container {
-    max-width: 102.4rem;
-  }
-}
-
-@media (max-width: 76.8rem) {
-  .container {
-    max-width: 76.8rem;
   }
 }
 

--- a/src/styles/_Variables.scss
+++ b/src/styles/_Variables.scss
@@ -7,8 +7,8 @@ $breakpoint-extra-small: 640px;
 $breakpoint-small: 768px;
 $breakpoint-medium: 1024px;
 
-$grid-max-width: 62rem;
-$container-max-width: 102.4rem;
-$container-max-width-sm: 64rem;
+$container-max-width: 1200px;
+
+$content-max-width: 620px;
 
 $box-shadow: 0px 0px 50px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
Consolidates a few different container sizes and breakpoints to result in better responsive scaling. The only remaining container breakpoint is at 1024px.

https://user-images.githubusercontent.com/4661832/160936220-40a1b70e-a051-43ae-969b-be93cd9430b7.mov


