### PR TITLE
Fix errors on undefined values

### DIFF
--- a/src/hooks/useFocusFirstNewResult.js
+++ b/src/hooks/useFocusFirstNewResult.js
@@ -13,7 +13,7 @@ export default function useFocusFirstNewResult(posts) {
   const [firstNewResultIndex, setFirstnewResultIndex] = useState(0);
 
   useEffect(() => {
-    const isPaginated = posts.length > appConfig.postsPerPage;
+    const isPaginated = posts && posts.length > appConfig.postsPerPage;
 
     if (isPaginated) {
       firstNewResultRef.current?.focus();

--- a/src/hooks/useNodePagination.js
+++ b/src/hooks/useNodePagination.js
@@ -55,7 +55,7 @@ export default function useNodePagination(queryFn, prepassItems) {
        * Optional merge function
        */
       merge({ data: { existing, incoming }, uniqBy }) {
-        if (existing) {
+        if (existing?.nodes && incoming?.nodes) {
           return {
             ...incoming,
             // If using 'cache-and-network', you have to use `uniqBy`


### PR DESCRIPTION
## Description

1. Prevents error accessing `posts.length` if `posts` is ever undefined. I only ran into this error once or twice and couldn't reliably reproduce it, but I think the patch still makes sense.
2. Prevents an error in `useNodePagination` when navigating from index -> single views. Reproduction steps for this one are provided below.

I'll submit these changes to the other blueprints once it's approved here.

## To reproduce
1. Load the blueprint home page.
2. Visit the "Portfolio" page.
4. Click the first project, "PHP Compatibility Checker".
5. See the following error.
<img width="1266" alt="Screen Shot 2022-04-07 at 4 14 33 PM" src="https://user-images.githubusercontent.com/4661832/163252402-95f5ee55-8edf-410b-a607-7c3c7db1918d.png">

## Testing

Using the reproduction steps above, you should no longer encounter an error.

