### PR TITLE
[MERL-334] build(security): Bump undici to 5.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -674,13 +674,13 @@
       }
     },
     "node_modules/@gqty/cli": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@gqty/cli/-/cli-3.2.0.tgz",
-      "integrity": "sha512-fHf2YxJXxGqOGEyZpb0bVRPAFbETv009X/R3Jc9T36PzNOdBqtGeckvn1B1dJUW6j8v5VW62vfwhWO+IOdHh5g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@gqty/cli/-/cli-3.3.0.tgz",
+      "integrity": "sha512-V0qJFpxTZBKgqu/Z1sr9WNRosnv58vYeMEVM3ozSrIMhz29DIheUT4cQgs7eF8xFf2+wsbqEp6Rs/yq6z78Yew==",
       "dev": true,
       "dependencies": {
         "gqty": "^2.2.0",
-        "undici": "^4.15.0"
+        "undici": "^5.2.0"
       },
       "bin": {
         "gqty": "bin.mjs"
@@ -6669,9 +6669,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.16.0.tgz",
-      "integrity": "sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
       "dev": true,
       "engines": {
         "node": ">=12.18"
@@ -7538,13 +7538,13 @@
       }
     },
     "@gqty/cli": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@gqty/cli/-/cli-3.2.0.tgz",
-      "integrity": "sha512-fHf2YxJXxGqOGEyZpb0bVRPAFbETv009X/R3Jc9T36PzNOdBqtGeckvn1B1dJUW6j8v5VW62vfwhWO+IOdHh5g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@gqty/cli/-/cli-3.3.0.tgz",
+      "integrity": "sha512-V0qJFpxTZBKgqu/Z1sr9WNRosnv58vYeMEVM3ozSrIMhz29DIheUT4cQgs7eF8xFf2+wsbqEp6Rs/yq6z78Yew==",
       "dev": true,
       "requires": {
         "gqty": "^2.2.0",
-        "undici": "^4.15.0"
+        "undici": "^5.2.0"
       }
     },
     "@gqty/logger": {
@@ -12020,9 +12020,9 @@
       }
     },
     "undici": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.16.0.tgz",
-      "integrity": "sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
       "dev": true
     },
     "uri-js": {


### PR DESCRIPTION
Related ticket: https://wpengine.atlassian.net/browse/MERL-334