### PR TITLE
Bumped undici to 5.10.0 (most recent version)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6669,9 +6669,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.0.tgz",
-      "integrity": "sha512-1F7Vtcez5w/LwH2G2tGnFIihuWUlc58YidwLiCv+jR2Z50x0tNXpRRw7eOIJ+GvqCqIkg9SB7NWAJ/T9TLfv8Q==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
+      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
       "dev": true,
       "engines": {
         "node": ">=12.18"
@@ -12020,9 +12020,9 @@
       }
     },
     "undici": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.0.tgz",
-      "integrity": "sha512-1F7Vtcez5w/LwH2G2tGnFIihuWUlc58YidwLiCv+jR2Z50x0tNXpRRw7eOIJ+GvqCqIkg9SB7NWAJ/T9TLfv8Q==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
+      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
       "dev": true
     },
     "uri-js": {


### PR DESCRIPTION
Updated via `npm update undici` to the latest version, 5.10.0 (dependabot requested 5.8.2, but updating 5.10.0 is most recent)