### PR TITLE
Add back search relay pagination, remove recent posts from search page

### DIFF
--- a/components/SearchRecommendations/SearchRecommendations.js
+++ b/components/SearchRecommendations/SearchRecommendations.js
@@ -6,25 +6,13 @@ import styles from './SearchRecommendations.module.scss';
  * Render the SearchRecommendations component.
  *
  * @param {Props} props The props object.
- * @param {Array} props.recentPosts Array of recent posts from WordPress
  * @param {Array} props.categories Array of categories from WordPress
  *
  * @returns {React.ReactElement} The SearchRecommendations component.
  */
-export default function SearchRecommendations({ recentPosts, categories }) {
+export default function SearchRecommendations({ categories }) {
   return (
     <div className={styles.recommendations}>
-      <h4>Recent Posts</h4>
-      <ul>
-        {recentPosts?.map((node) => (
-          <li key={node.databaseId}>
-            <Link href={node.uri}>
-              <a>{node.title}</a>
-            </Link>
-          </li>
-        ))}
-      </ul>
-
       <h4>Browse by Category</h4>
       <ul>
         {categories?.map((node) => (

--- a/pages/search.js
+++ b/pages/search.js
@@ -28,7 +28,6 @@ export default function Page() {
   const { title: siteTitle, description: siteDescription } =
     pageData.generalSettings;
   const primaryMenu = pageData.headerMenuItems.nodes ?? [];
-  const recentPosts = pageData.posts.nodes;
   const categories = pageData.categories.nodes;
 
   const {
@@ -103,10 +102,7 @@ export default function Page() {
           )}
 
           {!searchResultsLoading && searchResultsData === undefined && (
-            <SearchRecommendations
-              recentPosts={recentPosts}
-              categories={categories}
-            />
+            <SearchRecommendations categories={categories} />
           )}
         </div>
       </Main>
@@ -141,15 +137,6 @@ Page.query = gql`
         ...NavigationMenuItemFragment
       }
     }
-    # Recent Posts
-    posts(first: 5) {
-      nodes {
-        databaseId
-        uri
-        title
-      }
-    }
-    # Post Categories
     categories {
       nodes {
         databaseId

--- a/plugins/RelayStylePaginationPlugin.js
+++ b/plugins/RelayStylePaginationPlugin.js
@@ -15,6 +15,7 @@ export class RelayStylePaginationPlugin {
               ...options.typePolicies.RootQuery.fields,
               posts: relayStylePagination(),
               projects: relayStylePagination(),
+              contentNodes: relayStylePagination(),
             },
           },
           ContentType: {


### PR DESCRIPTION
This PR:
* Adds back relay style pagination to search
* Removes the recent posts from the search page
  * Was noticing that this request was sometimes forcing the page to do a CSR request on page transitions, so removing until we know what is going on.