### PR TITLE
Bump faustwp/cli to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.7.0",
-    "@faustwp/cli": "0.1.4",
+    "@faustwp/cli": "0.1.5",
     "@faustwp/core": "0.1.3",
     "classnames": "^2.3.1",
     "graphql": "^16.6.0",


### PR DESCRIPTION
So that new `FAUST_NO_INTERACTION` env vars work when creating Faust.js sites from a blueprint in Local.

## Context
The `@faustwp/cli` package introduced a `FAUST_NO_INTERACTION` env var in [0.1.5](https://github.com/wpengine/faustjs/releases/tag/%40faustwp%2Fcli%400.1.5) at https://github.com/wpengine/faustjs/pull/1162. It allows unsupervised installation of Faust without a user prompt to accept/decline telemetry.

The [Local Atlas add on](https://github.com/getflywheel/local-addon-atlas) runs [npm install](https://github.com/getflywheel/local-addon-atlas/blob/c2b6cbea5cb732f45876af53d137d80bea8e8fd6/src/NodeJSService.ts#L72) in this blueprint's directory when the site is first cloned.

Without this version bump to 0.1.5, faustwp/cli 0.1.4 gets installed during blueprint setup. This means the new `FAUST_NO_INTERACTION` env var is ignored and the node server never gets beyond the telemetry prompt.
