### PR TITLE
fix: prevent Local 502 error by using unoptimized images

### DIFF
--- a/components/FeaturedImage/FeaturedImage.js
+++ b/components/FeaturedImage/FeaturedImage.js
@@ -38,6 +38,7 @@ export default function FeaturedImage({
         alt={altText}
         objectFit="cover"
         layout="responsive"
+        unoptimized={true}
         {...props}
       />
     </figure>

--- a/components/Header/Header.js
+++ b/components/Header/Header.js
@@ -37,6 +37,7 @@ export default function Header({ className, menuItems }) {
                   height={80}
                   alt="Blueprint media logo"
                   layout="responsive"
+                  unoptimized={true}
                 />
               </a>
             </Link>


### PR DESCRIPTION
[Local 6.6+](https://localwp.com/releases/) uses Electron 21, which implements a new memory cage feature:

https://www.electronjs.org/blog/v8-memory-cage

The memory cage prevents Node.js modules such as sharp from working:

https://github.com/lovell/sharp/issues/3384

Sharp is used by Next.js to optimize images.

The result is that Local's Node.js process crashes, resulting in a 502 when Local 6.6+ users create new sites using this blueprint, due to the optimized logo image in the header and in featured images:

<img width="846" alt="Screenshot 2022-12-22 at 13 42 56" src="https://user-images.githubusercontent.com/647669/209140086-5e4d2e30-15ee-4c8c-90bf-2879d7dce663.png">

Using the `unoptimized` prop prevents this for now.

This workaround could be removed when Electron updates with the patched version of Node.js that allows sharp's workaround to function, and when Local has updated to that Electron version. (The Electron 21 patch has not been released at the time of writing: https://github.com/electron/electron/pull/36625 )