### PR TITLE
fix: update sharp to fix images under Electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-dom": "17.0.2",
     "react-icons": "4.6.0",
     "react-responsive-carousel": "3.2.23",
-    "sharp": "^0.31.1",
+    "sharp": "^0.31.3",
     "use-debounce": "8.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Adopts the latest version of the Sharp library. This will allow image processing to work with the latest versions of Electron once it updates with a fix for the memory cage issue.

See https://github.com/lovell/sharp/issues/3384 (this fix in Sharp is out now).
And https://github.com/electron/electron/pull/36625 (this fix in Electron is not yet published).

This does not immediately fix the error outlined in #103 where starting a new site with this blueprint under Local 6.6+ causes a 502 error, but it will allow the blueprint to load once Electron and Local update. (The Local team is awaiting a patch in Electron. The workaround for now is to use Local 6.5.2 from https://localwp.com/releases/.)

Replaces #103, which fixed the issue immediately, but had the unwanted side-effect of also using unoptimized images in non-Electron contexts.

