### PR TITLE
Build: Use Node v18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16' ]
+        node: ['16', '18' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
# Description

This PR updates the GH Actions to use Node v16 and Node v18 instead of Node v14