### PR TITLE
rebranding from atlas to headless platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Atlas Blueprint Portfolio
+# Headless Platform Blueprint Portfolio
 
-This repository contains a starter Blueprint to get you up and running quickly on [WP Engine's Atlas platform](https://wpengine.com/atlas/) with a WordPress site complete with a blog, portfolio and testimonials.
+This repository contains a starter Blueprint to get you up and running quickly on [WP Engine's Headless Platform](https://wpengine.com/atlas/) with a WordPress site complete with a blog, portfolio and testimonials.
 
 ## For more information
 
 For more information on this Blueprint please check out the following sources:
 
-- [WP Engine's Atlas Platform](https://wpengine.com/atlas/)
+- [WP Engine's Headless Platform](https://wpengine.com/atlas/)
 - [Faust.js](https://faustjs.org)
 - [WPGraphQL](https://www.wpgraphql.com)
 - [Atlas Content Modeler](https://wordpress.org/plugins/atlas-content-modeler/)
-- [WP Engine's Atlas developer community](https://developers.wpengine.com)
+- [WP Engine's Headless Platform developer community](https://developers.wpengine.com)
 
 ### Contributor License Agreement
 

--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -120,7 +120,9 @@ export default function Footer({ menuItems }) {
 
         <div className={cx('copyright')}>
           &copy; {new Date().getFullYear()} Blueprint Media &#183; Powered By{' '}
-          <a href="https://wpengine.com/headless-wordpress">Headless Platform</a>
+          <a href="https://wpengine.com/headless-wordpress">
+            Headless Platform
+          </a>
         </div>
       </div>
     </footer>

--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -120,7 +120,7 @@ export default function Footer({ menuItems }) {
 
         <div className={cx('copyright')}>
           &copy; {new Date().getFullYear()} Blueprint Media &#183; Powered By{' '}
-          <a href="https://wpengine.com/atlas">Atlas</a>
+          <a href="https://wpengine.com/headless-wordpress">Headless Platform</a>
         </div>
       </div>
     </footer>

--- a/wp-templates/front-page.js
+++ b/wp-templates/front-page.js
@@ -77,8 +77,9 @@ export default function Component() {
               )}
             >
               <span>
-                Learn about Core Web Vitals and how Headless Platform can help you reach
-                your most demanding speed and user experience requirements.
+                Learn about Core Web Vitals and how Headless Platform can help
+                you reach your most demanding speed and user experience
+                requirements.
               </span>
             </CTA>
           </section>

--- a/wp-templates/front-page.js
+++ b/wp-templates/front-page.js
@@ -97,8 +97,9 @@ export default function Component() {
               )}
             >
               <span>
-                Learn about Core Web Vitals and how Headless Platform can help you reach
-                your most demanding speed and user experience requirements.
+                Learn about Core Web Vitals and how Headless Platform can help
+                you reach your most demanding speed and user experience
+                requirements.
               </span>
             </CTA>
           </section>

--- a/wp-templates/front-page.js
+++ b/wp-templates/front-page.js
@@ -77,7 +77,7 @@ export default function Component() {
               )}
             >
               <span>
-                Learn about Core Web Vitals and how Atlas can help you reach
+                Learn about Core Web Vitals and how Headless Platform can help you reach
                 your most demanding speed and user experience requirements.
               </span>
             </CTA>
@@ -97,7 +97,7 @@ export default function Component() {
               )}
             >
               <span>
-                Learn about Core Web Vitals and how Atlas can help you reach
+                Learn about Core Web Vitals and how Headless Platform can help you reach
                 your most demanding speed and user experience requirements.
               </span>
             </CTA>


### PR DESCRIPTION
Removing all customer-facing references to Atlas and replacing them with Headless Platform